### PR TITLE
Use note headline for buffer title.

### DIFF
--- a/simplenote2.el
+++ b/simplenote2.el
@@ -575,6 +575,8 @@ setting."
     (when create-flag
       (run-hooks 'simplenote2-create-note-hook))
     (simplenote2-note-mode)
+    ;; Rename buffer so the title isn't just the filename hash
+    (rename-buffer (simplenote2--note-headline (buffer-string)))
     ;; Refresh notes display after save
     (add-hook 'after-save-hook
               (lambda () (simplenote2-browser-refresh))


### PR DESCRIPTION
When opening a file from `simplenote2-browse`, the filename winds up
being a meaningless (to humans) text string. This commit uses the note
headline as a title for the buffer instead. This way, if you open
multiple notes in multiple buffers, you can actually tell which is
which.
