### PR TITLE
Filter note list by content

### DIFF
--- a/simplenote2.el
+++ b/simplenote2.el
@@ -122,6 +122,8 @@ to edit them, set this option to `markdown-mode'."
 
 (defvar simplenote2-tag-list nil)
 
+(defvar simplenote2-filtered-notes-list nil)
+
 (defconst simplenote2-notes-info-version 1)
 
 (defvar simplenote2-filter-note-tag-list nil)
@@ -785,8 +787,11 @@ are retrieved from the server forcefully."
 ;; Eventually this will do the work of applying the regex and whatnot
 (setq simplenote2--search-field
       (lambda (widget &rest ignore)
-        (let ((regexp (widget-value widget)))
-          nil)))
+        ;; TODO refactor this
+        (let* ((regexp (widget-value widget))
+               (grep-results (shell-command-to-string (concat "grep -il ~/.simplenote2/notes/* -e " regexp))))
+          ; (message "setting simplenote2-filtered-notes-list")
+          (setq simplenote2-filtered-notes-list (split-string grep-results "\n" t)))))
 
 (defun simplenote2--menu-setup ()
   (let ((inhibit-read-only t))

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -754,6 +754,12 @@ are retrieved from the server forcefully."
 (setq simplenote2-filter-note-by-and-condition
       (if simplenote2-filter-note-by-and-condition nil t)))
 
+(setq simplenote2--search-field
+      (lambda (widget &rest ignore)
+        (let ((regexp (widget-value widget)))
+          nil)))
+
+
 (defun simplenote2--menu-setup ()
   (let ((inhibit-read-only t))
     (erase-buffer))
@@ -782,6 +788,12 @@ are retrieved from the server forcefully."
                            (simplenote2-browser-refresh))
                  (format "Tag filter condition: %s"
                          (if simplenote2-filter-note-by-and-condition "AND" "OR")))
+  ;; Search field
+  (widget-insert "\n\n")
+  (widget-create 'editable-field
+                 :size 50
+                 :format "Search notes for: %v "
+                 :action simplenote2--search-field)
   (widget-insert "\n\n")
   ;; New notes list
   (let ((new-notes (directory-files (simplenote2--new-notes-dir) t "^note-[0-9]+$")))

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -726,7 +726,6 @@ are retrieved from the server forcefully."
 
 \\{simplenote2-browser-mode-map}"
   (kill-all-local-variables)
-  (setq buffer-read-only t)
   (use-local-map simplenote2-browser-mode-map)
   (simplenote2--menu-setup)
   (setq major-mode 'simplenote2-browser-mode

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -756,15 +756,12 @@ are retrieved from the server forcefully."
 (setq simplenote2-filter-note-by-and-condition
       (if simplenote2-filter-note-by-and-condition nil t)))
 
-(defun simplenote2--list-files ()
+(defun simplenote2--list-files (passed-files)
+  ;; If we're not searching from the filter, we need all of the files. If we
+  ;; are, then we need *only* those files from that match the pattern
   (let (files)
-    (setq files (append
-                 (mapcar (lambda (file) (cons file nil))
-                         (directory-files (simplenote2--notes-dir) t "^[a-zA-Z0-9_\\-]+$"))
-                 (mapcar (lambda (file) (cons file t))
-                         (directory-files (simplenote2--trash-dir) t "^[a-zA-Z0-9_\\-]+$"))))
-    (when files
-      (setq files (sort files (lambda (p1 p2) (simplenote2--file-newer-p (car p1) (car p2)))))
+    (when passed-files
+      (setq files (sort passed-files (lambda (p1 p2) (simplenote2--file-newer-p (car p1) (car p2)))))
       (setq files (sort files (lambda (p1 p2) (simplenote2--pinned-note-p (car p1) (car p2)))))
       (widget-insert "== NOTES")
       (dolist (tag simplenote2-filter-note-tag-list)
@@ -834,7 +831,14 @@ are retrieved from the server forcefully."
       (widget-insert "== NEW NOTES\n\n")
       (mapc 'simplenote2--new-note-widget new-notes)))
   ;; Other notes list
-  (simplenote2--list-files)
+  (let ((files
+         (or simplenote2-filtered-notes-list
+             (append
+              (mapcar (lambda (file) (cons file nil))
+                      (directory-files (simplenote2--notes-dir) t "^[a-zA-Z0-9_\\-]+$"))
+              (mapcar (lambda (file) (cons file t))
+                      (directory-files (simplenote2--trash-dir) t "^[a-zA-Z0-9_\\-]+$"))))))
+    (simplenote2--list-files files))
   (use-local-map simplenote2-browser-mode-map)
   (widget-setup))
 

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -820,10 +820,17 @@ are retrieved from the server forcefully."
                          (if simplenote2-filter-note-by-and-condition "AND" "OR")))
   ;; Search field
   (widget-insert "\n\n")
-  (widget-create 'editable-field
-                 :size 50
-                 :format "Search notes for: %v "
-                 :action simplenote2--search-field)
+  (let ((search-field
+         (widget-create 'editable-field
+                        :size 40
+                        :format "Search notes for:\n%v "
+                        :action simplenote2--search-field)))
+    (widget-insert " ")
+    (widget-create-child-and-convert
+     search-field 'push-button
+     :tag " Search "
+     :action (lambda (widget &optional _event)
+               (funcall simplenote2--search-field (widget-get widget :parent)))))
   (widget-insert "\n\n")
   ;; New notes list
   (let ((new-notes (directory-files (simplenote2--new-notes-dir) t "^note-[0-9]+$")))

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -7,6 +7,7 @@
 ;; Based on: simplenote.el
 ;;     by Konstantinos Efstathiou <konstantinos@efstathiou.gr>
 ;; Package-Requires: ((request-deferred "0.2.0"))
+;; Package-Version: 20160916.622
 ;; Keywords: simplenote
 ;; Version: 2.2.2
 
@@ -29,7 +30,7 @@
 ;; This is a new version of simplenote.el which assists the interaction with
 ;; Simplenote (http://app.simplenote.com/). The major improvement points from
 ;; the original version are
-;; 
+;;
 ;; * Use of Simplenote API ver.2 to interact with server which can provide the
 ;;   support of tags, automatic merge of notes, and some other features.
 ;; * Asynchronous and concurrent access to server which brings faster sync of
@@ -147,11 +148,11 @@ to edit them, set this option to `markdown-mode'."
 
 (defun simplenote2--make-tag-list ()
   (let ((files
-	 (mapcar 'file-name-nondirectory
-		 (append
-		  (directory-files (simplenote2--notes-dir) t "^[a-zA-Z0-9_\\-]+$")
-		  (directory-files (simplenote2--trash-dir) t "^[a-zA-Z0-9_\\-]+$"))))
-	tag-list)
+     (mapcar 'file-name-nondirectory
+         (append
+          (directory-files (simplenote2--notes-dir) t "^[a-zA-Z0-9_\\-]+$")
+          (directory-files (simplenote2--trash-dir) t "^[a-zA-Z0-9_\\-]+$"))))
+    tag-list)
     (dolist (file files)
       (let ((note-info (gethash file simplenote2-notes-info)))
         (dolist (tag (nth 4 note-info))
@@ -418,7 +419,7 @@ server is concatenated to the index provided by INDEX."
 (defun simplenote2-push-buffer ()
   "Push changes to server which are added to the note currently visiting
 
-This function works depending on where the current buffer file is located. 
+This function works depending on where the current buffer file is located.
 1) If the file is on new note directory, it does just the same process as
    `simplenote2-create-note-from-buffer'.
 2) If the file is on notes directory, it requests server to merge changes


### PR DESCRIPTION
I've been working on some things to make this mode work better for me, and I wonder what you'd think of them. Basically, this set of commits adds a search bar widget to the top of the buffer: you can enter a regex, which then `grep`s the simplenote2-notes-dir. 

It's not perfect: I was trying to find a way to leverage Emacs's grep-mode, but couldn't seem to find a way to get it to avoid opening a compilation-mode buffer. It's fine if you don't want to merge this, but it might be useful to some people.
