### PR TITLE
fix for alpha22jp#36

### DIFF
--- a/simplenote2.el
+++ b/simplenote2.el
@@ -279,6 +279,7 @@ LIMIT specifies the limit of variables to dump."
         (simplenote2--dump-variable 'simplenote2-notes-info)
         (simplenote2--dump-variable 'simplenote2-tag-list)
         (simplenote2--dump-variable 'simplenote2-notes-info-version)
+        (pp-buffer)
         (write-file (simplenote2--filename-for-notes-info))
         nil)
     (error (warn "Simplenote2: %s" (error-message-string error)))))

--- a/simplenote2.el
+++ b/simplenote2.el
@@ -399,7 +399,7 @@ of syncing note.  Notes marked as deleted are not included in the list."
               (if (request-response-error-thrown res)
                   (progn (message "Could not get index") t)
                 (mapc (lambda (e)
-                        (if (equal (cdr (assq 'deleted (cdr (assq 'd e)))) :json-false)
+                        (if (member (cdr (assq 'deleted (cdr (assq 'd e)))) '(:json-false 0))
                           (push (cons (cdr (assq 'id e))
                                     (cdr (assq 'v e))) index)))
                       (cdr (assq 'index (request-response-data res))))


### PR DESCRIPTION
changes indexing to be more permissive about the `deleted` flag since clients may use either `0` or `:json-false` (as discussed in #36) 